### PR TITLE
Logout fix

### DIFF
--- a/Innofactor.SuomiFiIdentificationClient.Test/Innofactor.SuomiFiIdentificationClient.Test.csproj
+++ b/Innofactor.SuomiFiIdentificationClient.Test/Innofactor.SuomiFiIdentificationClient.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -39,10 +39,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.1.18\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.1.18\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -72,8 +72,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
   </Target>
-  <Import Project="..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.18\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
 </Project>

--- a/Innofactor.SuomiFiIdentificationClient.Test/SuomiFiIdentificationClientTests.cs
+++ b/Innofactor.SuomiFiIdentificationClient.Test/SuomiFiIdentificationClientTests.cs
@@ -56,7 +56,7 @@ namespace Innofactor.SuomiFiIdentificationClient.Test {
     [TestMethod]
     public void Logout() {
 
-      var result = client.Logout();
+      var result = client.Logout("", "");
 
       Assert.IsNotNull(result, "result");
       Assert.IsTrue(result.StartsWith("https://testi.apro.tunnistus.fi/idp/profile/SAML2/Redirect/SLO?SAMLRequest"), "Start of request URL");

--- a/Innofactor.SuomiFiIdentificationClient.Test/packages.config
+++ b/Innofactor.SuomiFiIdentificationClient.Test/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MSTest.TestAdapter" version="1.1.18" targetFramework="net461" />
-  <package id="MSTest.TestFramework" version="1.1.18" targetFramework="net461" />
+  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net461" />
+  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net461" />
 </packages>

--- a/Innofactor.SuomiFiIdentificationClient/Saml/AttributeNames.cs
+++ b/Innofactor.SuomiFiIdentificationClient/Saml/AttributeNames.cs
@@ -8,7 +8,7 @@
 
     public const string Sn = "urn:oid:2.5.4.4";
 
-    public const string LogoutNameIdentifier = "http://kentor.se/AuthServices/LogoutNameIdentifier";
+    public const string NameIdentifier = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier";
   
     public const string SessionIndex = "http://kentor.se/AuthServices/SessionIndex";
 

--- a/Innofactor.SuomiFiIdentificationClient/Saml/AttributeNames.cs
+++ b/Innofactor.SuomiFiIdentificationClient/Saml/AttributeNames.cs
@@ -8,6 +8,10 @@
 
     public const string Sn = "urn:oid:2.5.4.4";
 
+    public const string LogoutNameIdentifier = "http://kentor.se/AuthServices/LogoutNameIdentifier";
+  
+    public const string SessionIndex = "http://kentor.se/AuthServices/SessionIndex";
+
   }
 
 }

--- a/Innofactor.SuomiFiIdentificationClient/Saml/Saml2AuthResponse.cs
+++ b/Innofactor.SuomiFiIdentificationClient/Saml/Saml2AuthResponse.cs
@@ -96,7 +96,7 @@ namespace Innofactor.SuomiFiIdentificationClient.Saml
       var nameId = identity.FindFirstValue(AttributeNames.LogoutNameIdentifier);
       var sessionId = identity.FindFirstValue(AttributeNames.SessionIndex);
 
-      return new Saml2AuthResponse(true) { FirstName = firstName, LastName = lastName, SSN = ssn, RelayState = response.RelayState, NameId = nameId, SessionId = sessionId };
+      return new Saml2AuthResponse(true) { FirstName = firstName, LastName = lastName, SSN = ssn, RelayState = response.RelayState, LogoutNameIdentifier = nameId, SessionIndex = sessionId };
 
     }
 
@@ -114,13 +114,13 @@ namespace Innofactor.SuomiFiIdentificationClient.Saml
 
     public string SSN { get; set; }
     /// <summary>
-    /// Name identifier used for Suomi.Fi logout request
+    /// Name identifier values used for Suomi.Fi logout request
     /// </summary>
-    public string NameId { get; set; }
+    public string LogoutNameIdentifier { get; set; }
     /// <summary>
     /// Session identifier for Suomi.Fi logout request
     /// </summary>
-    public string SessionId { get; set; }
+    public string SessionIndex { get; set; }
     public Saml2StatusCode Status { get; set; }
 
     public bool Success { get; set; }

--- a/Innofactor.SuomiFiIdentificationClient/Saml/Saml2AuthResponse.cs
+++ b/Innofactor.SuomiFiIdentificationClient/Saml/Saml2AuthResponse.cs
@@ -93,10 +93,10 @@ namespace Innofactor.SuomiFiIdentificationClient.Saml
       var firstName = identity.FindFirstValue(AttributeNames.GivenName);
       var lastName = identity.FindFirstValue(AttributeNames.Sn);
       var ssn = identity.FindFirstValue(AttributeNames.NationalIdentificationNumber);
-      var nameId = identity.FindFirstValue(AttributeNames.LogoutNameIdentifier);
+      var nameId = identity.FindFirstValue(AttributeNames.NameIdentifier);
       var sessionId = identity.FindFirstValue(AttributeNames.SessionIndex);
 
-      return new Saml2AuthResponse(true) { FirstName = firstName, LastName = lastName, SSN = ssn, RelayState = response.RelayState, LogoutNameIdentifier = nameId, SessionIndex = sessionId };
+      return new Saml2AuthResponse(true) { FirstName = firstName, LastName = lastName, SSN = ssn, RelayState = response.RelayState, NameIdentifier = nameId, SessionIndex = sessionId };
 
     }
 
@@ -114,9 +114,9 @@ namespace Innofactor.SuomiFiIdentificationClient.Saml
 
     public string SSN { get; set; }
     /// <summary>
-    /// Name identifier values used for Suomi.Fi logout request
+    /// Name / Session identifier used for Suomi.Fi logout request
     /// </summary>
-    public string LogoutNameIdentifier { get; set; }
+    public string NameIdentifier { get; set; }
     /// <summary>
     /// Session identifier for Suomi.Fi logout request
     /// </summary>

--- a/Innofactor.SuomiFiIdentificationClient/Saml/Saml2AuthResponse.cs
+++ b/Innofactor.SuomiFiIdentificationClient/Saml/Saml2AuthResponse.cs
@@ -13,10 +13,12 @@ using Kentor.AuthServices.Configuration;
 using Kentor.AuthServices.Saml2P;
 using Microsoft.Extensions.Logging;
 
-namespace Innofactor.SuomiFiIdentificationClient.Saml {
+namespace Innofactor.SuomiFiIdentificationClient.Saml
+{
 
   [Serializable]
-  public class Saml2AuthResponse {
+  public class Saml2AuthResponse
+  {
 
     private static readonly ILogger<Saml2AuthResponse> log = new LoggerFactory().CreateLogger<Saml2AuthResponse>();
     private static readonly string RsaSha256Namespace = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
@@ -28,7 +30,8 @@ namespace Innofactor.SuomiFiIdentificationClient.Saml {
     }
 
     // For testing only, when the tokens need to be re-used.
-    class DummyTokenReplayCache : TokenReplayCache {
+    class DummyTokenReplayCache : TokenReplayCache
+    {
       public override void AddOrUpdate(string key, SecurityToken securityToken, DateTime expirationTime) {
 
       }
@@ -46,7 +49,7 @@ namespace Innofactor.SuomiFiIdentificationClient.Saml {
       }
     }
 
-    public static Saml2AuthResponse Create(string samlResponse, 
+    public static Saml2AuthResponse Create(string samlResponse,
       Saml2Id responseToId,
       EntityId issuer,
       X509Certificate2 idpCert,
@@ -90,8 +93,10 @@ namespace Innofactor.SuomiFiIdentificationClient.Saml {
       var firstName = identity.FindFirstValue(AttributeNames.GivenName);
       var lastName = identity.FindFirstValue(AttributeNames.Sn);
       var ssn = identity.FindFirstValue(AttributeNames.NationalIdentificationNumber);
+      var nameId = identity.FindFirstValue(AttributeNames.LogoutNameIdentifier);
+      var sessionId = identity.FindFirstValue(AttributeNames.SessionIndex);
 
-      return new Saml2AuthResponse(true) { FirstName = firstName, LastName = lastName, SSN = ssn, RelayState = response.RelayState };
+      return new Saml2AuthResponse(true) { FirstName = firstName, LastName = lastName, SSN = ssn, RelayState = response.RelayState, NameId = nameId, SessionId = sessionId };
 
     }
 
@@ -108,7 +113,14 @@ namespace Innofactor.SuomiFiIdentificationClient.Saml {
     public string RelayState { get; set; }
 
     public string SSN { get; set; }
-
+    /// <summary>
+    /// Name identifier used for Suomi.Fi logout request
+    /// </summary>
+    public string NameId { get; set; }
+    /// <summary>
+    /// Session identifier for Suomi.Fi logout request
+    /// </summary>
+    public string SessionId { get; set; }
     public Saml2StatusCode Status { get; set; }
 
     public bool Success { get; set; }

--- a/Innofactor.SuomiFiIdentificationClient/Saml/Saml2LogoutRequest.cs
+++ b/Innofactor.SuomiFiIdentificationClient/Saml/Saml2LogoutRequest.cs
@@ -18,13 +18,13 @@ namespace Innofactor.SuomiFiIdentificationClient.Saml {
       var issueInstant = DateTime.UtcNow.ToSaml2DateTimeString();
 
       var x = new XElement(Saml2Namespaces.Saml2P + "LogoutRequest",
-        new XAttribute(XNamespace.Xmlns + "samlp", Saml2Namespaces.Saml2P),
+        new XAttribute(XNamespace.Xmlns + "saml2p", Saml2Namespaces.Saml2P),
         new XAttribute("Destination", destination),
         new XAttribute("ID", Id),
         new XAttribute("IssueInstant", issueInstant),
         new XAttribute("Version", "2.0"),
         new XElement(Saml2Namespaces.Saml2 + "Issuer",
-          new XAttribute(XNamespace.Xmlns + "saml", Saml2Namespaces.Saml2), entityId)
+          new XAttribute(XNamespace.Xmlns + "saml2", Saml2Namespaces.Saml2), entityId)
       );
 
       return x;

--- a/Innofactor.SuomiFiIdentificationClient/Saml/Saml2LogoutRequest.cs
+++ b/Innofactor.SuomiFiIdentificationClient/Saml/Saml2LogoutRequest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Data;
 using System.IdentityModel.Tokens;
 using System.Xml.Linq;
 using Kentor.AuthServices;
@@ -13,7 +14,7 @@ namespace Innofactor.SuomiFiIdentificationClient.Saml {
 
     public Saml2Id Id { get; }
 
-    public XElement ToXml(string entityId, string destination) {
+    public XElement ToXml(string entityId, string idpEntityId, string destination, string sessionId, string sessionIndex) {
 
       var issueInstant = DateTime.UtcNow.ToSaml2DateTimeString();
 
@@ -24,7 +25,14 @@ namespace Innofactor.SuomiFiIdentificationClient.Saml {
         new XAttribute("IssueInstant", issueInstant),
         new XAttribute("Version", "2.0"),
         new XElement(Saml2Namespaces.Saml2 + "Issuer",
-          new XAttribute(XNamespace.Xmlns + "saml2", Saml2Namespaces.Saml2), entityId)
+          new XAttribute(XNamespace.Xmlns + "saml2", Saml2Namespaces.Saml2), entityId),
+        new XElement(Saml2Namespaces.Saml2 + "NameID",
+          new XAttribute(XNamespace.Xmlns + "saml2", Saml2Namespaces.Saml2),
+          new XAttribute("Format", "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"),
+          new XAttribute("NameQualifier", idpEntityId),
+          new XAttribute("SPNameQualifier", entityId),
+            sessionId),
+        new XElement(Saml2Namespaces.Saml2P + "SessionIndex", sessionIndex)
       );
 
       return x;

--- a/Innofactor.SuomiFiIdentificationClient/SuomiFiIdentificationClient.cs
+++ b/Innofactor.SuomiFiIdentificationClient/SuomiFiIdentificationClient.cs
@@ -40,10 +40,10 @@ namespace Innofactor.SuomiFiIdentificationClient {
     /// Starts Suomi.fi logout request.
     /// </summary>
     /// <returns>Redirect URL</returns>
-    public string Logout() {
+    public string Logout(string sessionId, string sessionIndex) {
 
       var logoutRequest = new Saml2LogoutRequest();
-      var logoutRequestXml = logoutRequest.ToXml(config.Saml2EntityId, config.Saml2SLOUrl);
+      var logoutRequestXml = logoutRequest.ToXml(config.Saml2EntityId, config.Saml2IdpEntityId, config.Saml2SLOUrl, sessionId, sessionIndex);
       authStateAccessor.Id = logoutRequest.Id;
 
       var binding = new Saml2HttpRedirect(string.Empty, crypto);


### PR DESCRIPTION
Breaking change in order to end the session with suomi.fi properly. Requires session parameters for logging out. Included required values in original authentication response.