### PR TITLE
Fixing memorybuffer reading.

### DIFF
--- a/Innofactor.SuomiFiIdentificationClient/Saml/Saml2HttpRedirect.cs
+++ b/Innofactor.SuomiFiIdentificationClient/Saml/Saml2HttpRedirect.cs
@@ -47,8 +47,8 @@ namespace Innofactor.SuomiFiIdentificationClient.Saml {
         using (var writer = new StreamWriter(new DeflateStream(compressed, CompressionLevel.Optimal, true))) {
           writer.Write(payload);
         }
-
-        result = System.Net.WebUtility.UrlEncode(Convert.ToBase64String(compressed.GetBuffer()));
+        
+        result = System.Net.WebUtility.UrlEncode(Convert.ToBase64String(compressed.ToArray()));
       }
 
       return result;


### PR DESCRIPTION
Fixed memory buffer reading not to read whole buffer, but actual data. This fix empty extra data (long list of chars of AAAAAAAAAAAAAAAAAAAAA... ) in suomifi data.

Suomifi will change their validation after August 2023 and won't accept this extra data after that.