### PR TITLE
Fix issues with AesGcm algorithm dispose

### DIFF
--- a/Innofactor.SuomiFiIdentificationClient/Decryption/AesGcmDecryptor.cs
+++ b/Innofactor.SuomiFiIdentificationClient/Decryption/AesGcmDecryptor.cs
@@ -22,7 +22,7 @@ namespace Innofactor.SuomiFiIdentificationClient.Decryption {
     public int OutputBlockSize => throw new NotImplementedException();
 
     public void Dispose() {
-      throw new NotImplementedException();
+      // Nothing to dispose of
     }
 
     public int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset) {


### PR DESCRIPTION
Remove intentional 'not implemented exception' from algorithm dispose command because we have no resources requiring disposal of. 

Fixes issue #11 